### PR TITLE
Fix link to trumpet in readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -10,7 +10,7 @@ This example only includes the backend components.
 * [routes](https://npmjs.org/package/routes) - organize routing
 * [ecstatic](https://npmjs.org/package/ecstatic) - serve static files
 * [body](https://npmjs.org/package/body) - parse incoming form data
-* [trumpet](https://npmjs.org/package/ecstatic) - insert html into layouts
+* [trumpet](https://www.npmjs.com/package/trumpet) - insert html into layouts
 
 ## tcp-bind
 


### PR DESCRIPTION
The .org links 301, not sure if there's a reason to prefer them though.